### PR TITLE
Add systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,44 @@ It also restarts the services when a change occurs in them.
 
 This handler allows manual creation of services in the "iombian-services" folder, but the use of "IoMBian Installed Services Downloader" is recommended.
 
+## Installation
+
+- Define project name in an environment variable:
+
+> ```PROJECT_NAME=iombian-installed-services-handler```
+
+- Clone the repo into a temp folder:
+
+> ```git clone https://github.com/Tknika/${PROJECT_NAME}.git /tmp/${PROJECT_NAME} && cd /tmp/${PROJECT_NAME}```
+
+- Create the installation folder and move the appropriate files (edit the user):
+
+> ```sudo mkdir /opt/${PROJECT_NAME}```
+
+> ```sudo cp requirements.txt /opt/${PROJECT_NAME}```
+
+> ```sudo cp -r src/* /opt/${PROJECT_NAME}```
+
+> ```sudo cp systemd/${PROJECT_NAME}.service /etc/systemd/system/```
+
+> ```sudo chown -R iompi:iompi /opt/${PROJECT_NAME}```
+
+- Create the virtual environment and install the dependencies:
+
+> ```cd /opt/${PROJECT_NAME}```
+
+> ```python3 -m venv .venv```
+
+> ```source .venv/bin/activate```
+
+> ```pip install --upgrade pip```
+
+> ```pip install -r requirements.txt```
+
+- Start the script
+
+> ```sudo systemctl enable ${PROJECT_NAME}.service && sudo systemctl start ${PROJECT_NAME}.service```
+
 ## Docker
 To build the docker image, from the cloned repository, execute the docker build command in the same level as the Dockerfile:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ typer==0.12.3
 typing_extensions==4.11.0
 urllib3==2.2.1
 watchdog==4.0.0
+sdnotify==0.3.2

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,8 @@ import logging
 import os
 import signal
 
+import sdnotify
+
 from iombian_services_handler import IombianServicesHandler
 
 BASE_PATH = os.environ.get("BASE_PATH", "/opt/iombian-services")
@@ -22,6 +24,8 @@ if __name__ == "__main__":
     iombian_services_handler = IombianServicesHandler(BASE_PATH, WAIT_SECONDS)
     iombian_services_handler.read_local_services()
     iombian_services_handler.start()
+    notifier = sdnotify.SystemdNotifier()
+    notifier.notify("READY=1")
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)

--- a/systemd/iombian-installed-services-handler.service
+++ b/systemd/iombian-installed-services-handler.service
@@ -9,7 +9,7 @@ RestartSec=5
 TimeoutStopSec=5
 
 WorkingDirectory=/opt/iombian-installed-services-handler
-ExecStart=/opt/iombian-installed-services-handler/.venv/bin/python /opt/iombian-installed-service-handler/main.py
+ExecStart=/opt/iombian-installed-services-handler/.venv/bin/python /opt/iombian-installed-services-handler/src/main.py
 
 [Install]
-WantedBy=multy-user.target
+WantedBy=multi-user.target

--- a/systemd/iombian-installed-services-handler.service
+++ b/systemd/iombian-installed-services-handler.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=IoMBian Installed Services Handler
+
+[Service]
+Type=notify
+User=iompi
+Restart=always
+RestartSec=5
+TimeoutStopSec=5
+
+WorkingDirectory=/opt/iombian-installed-services-handler
+ExecStart=/opt/iombian-installed-services-handler/.venv/bin/python /opt/iombian-installed-service-handler/main.py
+
+[Install]
+WantedBy=multy-user.target


### PR DESCRIPTION
Add possibility to run this service with systemd.
- Added a .service file.
- Modified the main.py file to notify to systemd when the service is ready.
This is necessary because the "IoMBian Installed Services Downloader" needs to start after this service starts.
- Add the installation section to the readme explaining how to install and set up the systemd service.